### PR TITLE
Scaffold Next.js MVP base

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/app/cart/page.tsx
+++ b/app/cart/page.tsx
@@ -1,0 +1,10 @@
+export default function CartPage() {
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+      <h1 className="text-2xl font-semibold text-slate-900">Seu carrinho</h1>
+      <p className="mt-2 text-sm text-slate-600">
+        Ainda vazio. Este é o próximo passo após validarmos o catálogo.
+      </p>
+    </section>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,15 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+}
+
+body {
+  @apply bg-slate-50 text-slate-900;
+}
+
+main {
+  @apply mx-auto w-full max-w-5xl px-4 pb-12 pt-6;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,36 @@
+import "./globals.css";
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Cardápio Digital",
+  description: "Catálogo simples para restaurantes",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="pt-BR">
+      <body>
+        <header className="border-b border-slate-200 bg-white">
+          <div className="mx-auto flex w-full max-w-5xl items-center justify-between px-4 py-4">
+            <div>
+              <p className="text-xs uppercase tracking-widest text-slate-500">MVP</p>
+              <p className="text-xl font-semibold">Cardápio Digital</p>
+            </div>
+            <Link
+              href="/cart"
+              className="rounded-full border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-300 hover:bg-slate-50"
+            >
+              Carrinho
+            </Link>
+          </div>
+        </header>
+        <main>{children}</main>
+      </body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,68 @@
+const menuItems = [
+  {
+    id: 1,
+    name: "Hambúrguer artesanal",
+    description: "Pão brioche, blend da casa, queijo e molho especial.",
+    price: "R$ 32,00",
+  },
+  {
+    id: 2,
+    name: "Salada verde",
+    description: "Folhas frescas, tomate cereja e vinagrete cítrico.",
+    price: "R$ 24,00",
+  },
+  {
+    id: 3,
+    name: "Limonada da casa",
+    description: "Limão tahiti, hortelã e toque de gengibre.",
+    price: "R$ 12,00",
+  },
+];
+
+export default function Home() {
+  return (
+    <div className="space-y-6">
+      <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+        <p className="text-sm font-medium text-slate-500">Hello catalog</p>
+        <h1 className="mt-2 text-2xl font-semibold text-slate-900">
+          Catálogo simples para o MVP
+        </h1>
+        <p className="mt-2 text-sm text-slate-600">
+          Lista mockada para validar layout, conteúdo e navegação.
+        </p>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-lg font-semibold">Itens em destaque</h2>
+        <div className="grid gap-4 md:grid-cols-2">
+          {menuItems.map((item) => (
+            <article
+              key={item.id}
+              className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm"
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <h3 className="text-base font-semibold text-slate-900">
+                    {item.name}
+                  </h3>
+                  <p className="mt-1 text-sm text-slate-600">
+                    {item.description}
+                  </p>
+                </div>
+                <span className="text-sm font-semibold text-slate-900">
+                  {item.price}
+                </span>
+              </div>
+              <button
+                type="button"
+                className="mt-4 w-full rounded-xl border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-300 hover:bg-slate-50"
+              >
+                Adicionar ao carrinho
+              </button>
+            </article>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "cardapio-digital",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.5",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "20.14.10",
+    "@types/react": "18.3.3",
+    "@types/react-dom": "18.3.0",
+    "autoprefixer": "10.4.19",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.5",
+    "postcss": "8.4.39",
+    "tailwindcss": "3.4.6",
+    "typescript": "5.5.3"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,11 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: ["./app/**/*.{js,ts,jsx,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal, deployable MVP scaffold using Next.js App Router with TypeScript, ESLint and Tailwind so the product team can validate layout and navigation quickly.
- Deliver the smallest functional UI: base layout with header and a `Carrinho` link plus a mock catalog to validate flow and design decisions for Phase 1.

### Description
- Add project metadata and scripts in `package.json` with pinned `next`, `react` and `react-dom` versions and standard `dev|build|start|lint` scripts.
- Add TypeScript and Next config files: `tsconfig.json`, `next-env.d.ts`, and `next.config.mjs` to enable the App Router + TS developer experience.
- Configure Tailwind and PostCSS with `tailwind.config.ts`, `postcss.config.js`, and `app/globals.css` for styling defaults.
- Implement app router pages: `app/layout.tsx` (base layout + header + `Carrinho` link), `app/page.tsx` (mock catalog/home), and `app/cart/page.tsx` (placeholder cart page), and add `.eslintrc.json` for Next lint rules.

### Testing
- Attempted to scaffold and install dependencies with `npx create-next-app`, but dependency install failed due to `npm` registry access returning a 403 error, preventing running automated checks.
- No automated tests, `npm run lint`, or `next build` were executed because dependency installation was blocked by the registry error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d02aca854832a963afbd3d2b292aa)